### PR TITLE
Input would update the wrong field

### DIFF
--- a/Coiny/Coiny.xcodeproj/project.pbxproj
+++ b/Coiny/Coiny.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		CF970FFF2C2DEFE2004E8C4F /* CurrencyDataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF970FFE2C2DEFE2004E8C4F /* CurrencyDataResponse.swift */; };
 		CF9710022C2DF034004E8C4F /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710012C2DF034004E8C4F /* APIService.swift */; };
 		CF9710052C31E0E6004E8C4F /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710042C31E0E6004E8C4F /* DateFormatter+Extensions.swift */; };
+		CF9710072C32973E004E8C4F /* CurrencyInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710062C32973E004E8C4F /* CurrencyInputField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		CF970FFE2C2DEFE2004E8C4F /* CurrencyDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyDataResponse.swift; sourceTree = "<group>"; };
 		CF9710012C2DF034004E8C4F /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		CF9710042C31E0E6004E8C4F /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
+		CF9710062C32973E004E8C4F /* CurrencyInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyInputField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +114,7 @@
 			children = (
 				CF84B62E2C28482F00815617 /* FlagPickerView.swift */,
 				CF5A3F162BAF35B1005EF884 /* ConversionView.swift */,
+				CF9710062C32973E004E8C4F /* CurrencyInputField.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -217,6 +220,7 @@
 				CF84B62F2C28482F00815617 /* FlagPickerView.swift in Sources */,
 				CF5A3F172BAF35B1005EF884 /* ConversionView.swift in Sources */,
 				CF5A3F152BAF35B1005EF884 /* CoinyApp.swift in Sources */,
+				CF9710072C32973E004E8C4F /* CurrencyInputField.swift in Sources */,
 				CF9710052C31E0E6004E8C4F /* DateFormatter+Extensions.swift in Sources */,
 				CF5A3F232BAF3800005EF884 /* ConversionViewModel.swift in Sources */,
 			);

--- a/Coiny/Coiny.xcodeproj/project.pbxproj
+++ b/Coiny/Coiny.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		CF9710022C2DF034004E8C4F /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710012C2DF034004E8C4F /* APIService.swift */; };
 		CF9710052C31E0E6004E8C4F /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710042C31E0E6004E8C4F /* DateFormatter+Extensions.swift */; };
 		CF9710072C32973E004E8C4F /* CurrencyInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710062C32973E004E8C4F /* CurrencyInputField.swift */; };
+		CF9710092C32A1B0004E8C4F /* FocusField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9710082C32A1B0004E8C4F /* FocusField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +34,7 @@
 		CF9710012C2DF034004E8C4F /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		CF9710042C31E0E6004E8C4F /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		CF9710062C32973E004E8C4F /* CurrencyInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyInputField.swift; sourceTree = "<group>"; };
+		CF9710082C32A1B0004E8C4F /* FocusField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +126,7 @@
 			children = (
 				CF84B62C2C1DBA1400815617 /* FlagEmoji.swift */,
 				CF970FFE2C2DEFE2004E8C4F /* CurrencyDataResponse.swift */,
+				CF9710082C32A1B0004E8C4F /* FocusField.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -223,6 +226,7 @@
 				CF9710072C32973E004E8C4F /* CurrencyInputField.swift in Sources */,
 				CF9710052C31E0E6004E8C4F /* DateFormatter+Extensions.swift in Sources */,
 				CF5A3F232BAF3800005EF884 /* ConversionViewModel.swift in Sources */,
+				CF9710092C32A1B0004E8C4F /* FocusField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Coiny/Coiny/Pages/Conversion/Models/FocusField.swift
+++ b/Coiny/Coiny/Pages/Conversion/Models/FocusField.swift
@@ -1,0 +1,13 @@
+//
+//  FocusField.swift
+//  Coiny
+//
+//  Created by Christoffer Detlef on 01/07/2024.
+//
+
+import Foundation
+
+enum FocusField: Hashable {
+	case topSection
+	case bottomSection
+}

--- a/Coiny/Coiny/Pages/Conversion/Views/ConversionView.swift
+++ b/Coiny/Coiny/Pages/Conversion/Views/ConversionView.swift
@@ -11,9 +11,9 @@ struct ConversionView: View {
 	@State private var viewModel = ConversionViewModel()
 	@State private var topValue: Double? = nil
 	@State private var bottomValue: Double? = nil
-
 	@State private var presentFlagView = false
 	@State private var selectedField: String = ""
+
 	@FocusState private var primaryTextFieldFocusState: Bool
 	@FocusState private var secondaryTextFieldFocusState: Bool
 
@@ -62,13 +62,14 @@ struct ConversionView: View {
 		VStack(spacing: 0) {
 			Button {
 				selectedField = viewModel.selectedCurrency
+				primaryTextFieldFocusState = false
+				secondaryTextFieldFocusState = false
 				presentFlagView.toggle()
 			} label: {
 				currencySelector(viewModel.selectedCurrency)
 			}
 
-			input(topValue)
-				.focused($primaryTextFieldFocusState)
+			CurrencyInputField(value: $topValue, isFocused: _primaryTextFieldFocusState)
 			
 			Text("1 \(viewModel.secondarySelectedCurrency) = \(viewModel.convertCurrency(isTopSection: false)) \(viewModel.selectedCurrency)")
 				.font(.subheadline)
@@ -81,13 +82,14 @@ struct ConversionView: View {
 		VStack(spacing: 0) {
 			Button {
 				selectedField = viewModel.secondarySelectedCurrency
+				primaryTextFieldFocusState = false
+				secondaryTextFieldFocusState = false
 				presentFlagView.toggle()
 			} label: {
 				currencySelector(viewModel.secondarySelectedCurrency)
 			}
 			
-			input(bottomValue)
-				.focused($secondaryTextFieldFocusState)
+			CurrencyInputField(value: $bottomValue, isFocused: _secondaryTextFieldFocusState)
 			
 			Text("1 \(viewModel.selectedCurrency) = \(viewModel.convertCurrency(isTopSection: true)) \(viewModel.secondarySelectedCurrency)")
 				.font(.subheadline)
@@ -109,23 +111,6 @@ struct ConversionView: View {
 			}
 			.foregroundStyle(.black)
 		}
-	}
-	
-	private func input(_ selectedValue: Double?) -> some View {
-		TextField("0", value: Binding(
-			get: { selectedValue },
-			set: {
-				if primaryTextFieldFocusState {
-					topValue = $0
-				} else {
-					bottomValue = $0
-				}
-			}
-		),format: .number)
-		.keyboardType(.decimalPad)
-		.padding()
-		.multilineTextAlignment(.center) // Center the text inside the TextField
-		.font(.system(size: 60))
 	}
 
 	private func resetValues() {

--- a/Coiny/Coiny/Pages/Conversion/Views/ConversionView.swift
+++ b/Coiny/Coiny/Pages/Conversion/Views/ConversionView.swift
@@ -14,8 +14,7 @@ struct ConversionView: View {
 	@State private var presentFlagView = false
 	@State private var selectedField: String = ""
 
-	@FocusState private var primaryTextFieldFocusState: Bool
-	@FocusState private var secondaryTextFieldFocusState: Bool
+	@FocusState private var focusedField: FocusField?
 
 	var body: some View {
 		VStack(spacing: 20) {
@@ -43,12 +42,12 @@ struct ConversionView: View {
 			}
 		}
 		.onChange(of: topValue ?? 0) { _, input in
-			if primaryTextFieldFocusState {
+			if focusedField == .topSection {
 				bottomValue = viewModel.convertCurrency(input: input, isTopSection: true)
 			}
 		}
 		.onChange(of: bottomValue ?? 0) { _, input in
-			if secondaryTextFieldFocusState {
+			if focusedField == .bottomSection {
 				topValue = viewModel.convertCurrency(input: input, isTopSection: false)
 			}
 		}
@@ -62,14 +61,13 @@ struct ConversionView: View {
 		VStack(spacing: 0) {
 			Button {
 				selectedField = viewModel.selectedCurrency
-				primaryTextFieldFocusState = false
-				secondaryTextFieldFocusState = false
+				focusedField = nil
 				presentFlagView.toggle()
 			} label: {
 				currencySelector(viewModel.selectedCurrency)
 			}
 
-			CurrencyInputField(value: $topValue, isFocused: _primaryTextFieldFocusState)
+			CurrencyInputField(value: $topValue, field: .topSection, focusedField: _focusedField)
 			
 			Text("1 \(viewModel.secondarySelectedCurrency) = \(viewModel.convertCurrency(isTopSection: false)) \(viewModel.selectedCurrency)")
 				.font(.subheadline)
@@ -82,14 +80,13 @@ struct ConversionView: View {
 		VStack(spacing: 0) {
 			Button {
 				selectedField = viewModel.secondarySelectedCurrency
-				primaryTextFieldFocusState = false
-				secondaryTextFieldFocusState = false
+				focusedField = nil
 				presentFlagView.toggle()
 			} label: {
 				currencySelector(viewModel.secondarySelectedCurrency)
 			}
 			
-			CurrencyInputField(value: $bottomValue, isFocused: _secondaryTextFieldFocusState)
+			CurrencyInputField(value: $bottomValue, field: .bottomSection, focusedField: _focusedField)
 			
 			Text("1 \(viewModel.selectedCurrency) = \(viewModel.convertCurrency(isTopSection: true)) \(viewModel.secondarySelectedCurrency)")
 				.font(.subheadline)
@@ -114,8 +111,7 @@ struct ConversionView: View {
 	}
 
 	private func resetValues() {
-		primaryTextFieldFocusState = false
-		secondaryTextFieldFocusState = false
+		focusedField = nil
 		topValue = nil
 		bottomValue = nil
 	}

--- a/Coiny/Coiny/Pages/Conversion/Views/CurrencyInputField.swift
+++ b/Coiny/Coiny/Pages/Conversion/Views/CurrencyInputField.swift
@@ -1,0 +1,26 @@
+//
+//  CurrencyInputField.swift
+//  Coiny
+//
+//  Created by Christoffer Detlef on 01/07/2024.
+//
+
+import SwiftUI
+
+struct CurrencyInputField: View {
+	@Binding var value: Double?
+	@FocusState var isFocused: Bool
+
+	var body: some View {
+		TextField("0", value: $value, format: .number)
+			.keyboardType(.decimalPad)
+			.padding()
+			.multilineTextAlignment(.center)
+			.font(.system(size: 60))
+			.focused($isFocused)
+	}
+}
+
+#Preview {
+	CurrencyInputField(value: .constant(0))
+}

--- a/Coiny/Coiny/Pages/Conversion/Views/CurrencyInputField.swift
+++ b/Coiny/Coiny/Pages/Conversion/Views/CurrencyInputField.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct CurrencyInputField: View {
 	@Binding var value: Double?
-	@FocusState var isFocused: Bool
+	var field: FocusField
+	@FocusState var focusedField: FocusField?
 
 	var body: some View {
 		TextField("0", value: $value, format: .number)
@@ -17,10 +18,10 @@ struct CurrencyInputField: View {
 			.padding()
 			.multilineTextAlignment(.center)
 			.font(.system(size: 60))
-			.focused($isFocused)
+			.focused($focusedField, equals: field)
 	}
 }
 
 #Preview {
-	CurrencyInputField(value: .constant(0))
+	CurrencyInputField(value: .constant(0), field: .topSection)
 }


### PR DESCRIPTION
Updated the logic for the TextField, because pressing on the other TextField, would update the previous one without pressing any numbers.

Changed the FocusState logic, to be a bit more clean to look at.